### PR TITLE
Fix no-empty-source with empty files

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,19 @@ module.exports = function (options) {
   function transformResult(result, filepath) {
     const extractedToSourceLineMap = sourceToLineMap.get(filepath);
     const newWarnings = result.warnings.reduce((memo, warning) => {
+      // This might end up rendering to null when there's no content on the
+      // file being parsed. It's likely that it has been flagged due a
+      // `no-empty-source` rule.
       const warningSourceMap = extractedToSourceLineMap.get(warning.line);
-      if (warning.line) {
+
+      if (warning.line && warningSourceMap) {
         warning.line = warningSourceMap.line;
       }
-      if (warning.column) {
+
+      if (warning.column && warningSourceMap) {
         warning.column = warning.column + warningSourceMap.indentColumns;
       }
+
       memo.push(warning);
       return memo;
     }, []);

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ test('markdown', (t) => {
     t.equal(result.source, fixture, 'filename');
     t.deepEqual(_.orderBy(result.warnings, ['line', 'column']), markdownExpectedWarnings);
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 const htmlExpectedWarnings = [
@@ -104,7 +104,7 @@ test('html', (t) => {
 
     t.deepEqual(_.orderBy(result.warnings, ['line', 'column']), htmlExpectedWarnings);
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 test('markdown and html', (t) => {
@@ -123,7 +123,7 @@ test('markdown and html', (t) => {
     t.deepEqual(_.orderBy(data.results[1].warnings, ['line', 'column']), htmlExpectedWarnings);
 
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 test('actual css', (t) => {
@@ -133,9 +133,9 @@ test('actual css', (t) => {
     config,
   }).then((data) => {
     t.equal(data.results.length, 1, 'number of results');
-    t.equal(data.results.warnings().length, 0, 'no warnings');
+    t.equal(data.results[0].warnings.length, 0, 'no warnings');
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 const liquidExpectedWarnings = [
@@ -178,7 +178,7 @@ test('liquid, custom tags', (t) => {
     t.equal(result.source, fixture, 'filename');
     t.deepEqual(_.orderBy(result.warnings, ['line', 'column']), liquidExpectedWarnings);
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 test('vue', (t) => {
@@ -200,7 +200,7 @@ test('vue', (t) => {
       t.equal(warning.rule, 'selector-no-type');
     });
     t.end();
-  }).catch(t.end);
+  }).catch(t.threw);
 });
 
 test('empty files with no-empty-source rule should be parsed', (t) => {

--- a/test/test.js
+++ b/test/test.js
@@ -202,3 +202,24 @@ test('vue', (t) => {
     t.end();
   }).catch(t.end);
 });
+
+test('empty files with no-empty-source rule should be parsed', (t) => {
+  const fixture = path.join(__dirname, './fixtures/empty-file.html');
+  stylelint.lint({
+    files: [fixture],
+    config: {
+      processors: [pathToProcessor],
+      rules: {
+        'no-empty-source': true,
+      },
+    },
+  }).then((data) => {
+    t.equal(data.results.length, 1, 'number of results');
+    const result = data.results[0];
+    t.equal(result.source, fixture, 'filename');
+    result.warnings.forEach((warning) => {
+      t.equal(warning.rule, 'no-empty-source');
+    });
+    t.end();
+  }).catch(t.threw);
+});


### PR DESCRIPTION
58620a4 introduced a bug where one couldn't run Stylelint when there's an empty file and a
`no-empty-source` rule.

It would break Stylelint, resulting in something like:

```js
TypeError: Cannot read property 'line' of undefined
    at result.warnings.reduce (/home/appuser/app/node_modules/stylelint-processor-arbitrary-tags/index.js:72:40)
    at Array.reduce (<anonymous>)
    at transformResult (/home/appuser/app/node_modules/stylelint-processor-arbitrary-tags/index.js:69:41)
    at config.resultProcessors.forEach.resultProcessor (/home/appuser/app/node_modules/stylelint/lib/createStylelintResult.js:69:26)
    at Array.forEach (<anonymous>)
    at stylelint.getConfigForFile.then.result (/home/appuser/app/node_modules/stylelint/lib/createStylelintResult.js:66:31)
    at <anonymous>
```

This PR fixes it, as long as several testcases that were being silenced because a wrong function was being called on the `catch` callback.